### PR TITLE
Feature/add accordion block

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+name: Govuk-Components
+
+on: push
+
+jobs:
+  kahlan:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.4']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction
+      - name: Run Kahlan tests
+        run: vendor/bin/kahlan
+  php-cs-fixer:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.2', '7.4']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction
+      - name: PHP CS fix
+        run: vendor/bin/php-cs-fixer fix --dry-run -v --diff

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# GOV.UK Components
+
+A WordPress plugin that adds components from the [GOV.UK Frontend](https://design-system.service.gov.uk/components/) to the block editor.
+
+Requires ACF Pro.
+
+## Development
+
+### Install the dependencies:
+
+```
+composer install
+```
+
+### Run the tests:
+
+```
+vendor/bin/kahlan spec
+```
+
+### Run the linter:
+
+```
+vendor/bin/php-cs-fixer fix
+```

--- a/app/Blocks/Accordion.php
+++ b/app/Blocks/Accordion.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace GovukComponents\Blocks;
+
+class Accordion implements \Dxw\Iguana\Registerable
+{
+    /* the path to the template for this block from the root of the plugin */
+    public $templatePath = '/templates/accordion.php';
+
+    public $count = 0;
+
+    public function register()
+    {
+        add_action('init', [$this, 'registerBlock']);
+        add_action('init', [$this, 'registerFields']);
+    }
+
+    public function registerBlock()
+    {
+        if (function_exists('acf_register_block_type')) {
+            acf_register_block_type([
+                'name'              => 'accordion',
+                'title'             => 'Accordion',
+                'render_callback'   => [$this, 'render'],
+                'mode' => 'auto',
+                'category'          => 'formatting',
+                'icon'              => 'list-view',
+                'keywords'          => [ 'accordion' ],
+            ]);
+        }
+    }
+
+    public function registerFields()
+    {
+        if (function_exists('acf_add_local_field_group')):
+
+            acf_add_local_field_group([
+                'key' => 'group_600819a94d98b',
+                'title' => 'Accordion',
+                'fields' => [
+                    [
+                        'key' => 'field_600819addb417',
+                        'label' => 'Sections',
+                        'name' => 'accordion_sections',
+                        'type' => 'repeater',
+                        'instructions' => '',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'collapsed' => '',
+                        'min' => 1,
+                        'max' => 0,
+                        'layout' => 'block',
+                        'button_label' => 'Add Section',
+                        'sub_fields' => [
+                            [
+                                'key' => 'field_60081b8cdb418',
+                                'label' => 'Section heading',
+                                'name' => 'accordion_section_heading',
+                                'type' => 'text',
+                                'instructions' => '',
+                                'required' => 0,
+                                'conditional_logic' => 0,
+                                'wrapper' => [
+                                    'width' => '',
+                                    'class' => '',
+                                    'id' => '',
+                                ],
+                                'default_value' => '',
+                                'placeholder' => '',
+                                'prepend' => '',
+                                'append' => '',
+                                'maxlength' => '',
+                            ],
+                            [
+                                'key' => 'field_60081b94db419',
+                                'label' => 'Section content',
+                                'name' => 'accordion_section_content',
+                                'type' => 'wysiwyg',
+                                'instructions' => '',
+                                'required' => 0,
+                                'conditional_logic' => 0,
+                                'wrapper' => [
+                                    'width' => '',
+                                    'class' => '',
+                                    'id' => '',
+                                ],
+                                'default_value' => '',
+                                'tabs' => 'all',
+                                'toolbar' => 'full',
+                                'media_upload' => 1,
+                                'delay' => 0,
+                            ],
+                        ],
+                    ],
+                ],
+                'location' => [
+                    [
+                        [
+                            'param' => 'block',
+                            'operator' => '==',
+                            'value' => 'acf/accordion',
+                        ],
+                    ],
+                ],
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ]);
+            
+        endif;
+    }
+
+    public function render()
+    {
+        $this->count = $this->count + 1;
+        load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false, [
+            'govuk-components-accordion-count' => $this->count
+        ]);
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -1,1 +1,3 @@
 <?php
+
+$registrar->addInstance(new \GovukComponents\Blocks\Accordion());

--- a/app/load.php
+++ b/app/load.php
@@ -2,4 +2,4 @@
 
 require __DIR__.'/../vendor.phar';
 
-return \Dxw\Iguana\Init::init(__DIR__, MyPlugin::class);
+return \Dxw\Iguana\Init::init(__DIR__, GovukComponents::class);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "autoload": {
     "psr-4": {
-      "MyPlugin\\": "app/"
+      "GovukComponents\\": "app/"
     }
   },
   "scripts": {

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 /*
-Plugin Name: My Plugin
-Description: TODO
+Plugin Name: GOV.UK Components
+Description: Adds components from the GOV.UK Frontend to the block editor
 Version: 0.1.0
 Author: dxw
 Author URI: https://www.dxw.com

--- a/spec/blocks/accordion.spec.php
+++ b/spec/blocks/accordion.spec.php
@@ -1,0 +1,64 @@
+<?php
+
+use Kahlan\Arg;
+
+describe(\GovukComponents\Blocks\Accordion::class, function () {
+    beforeEach(function () {
+        $this->accordion = new \GovukComponents\Blocks\Accordion();
+    });
+
+    it('is registerable', function () {
+        expect($this->accordion)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the actions', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->accordion, 'registerBlock']);
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->accordion, 'registerFields']);
+            $this->accordion->register();
+        });
+    });
+
+    describe('->registerBlock()', function () {
+        it('registers the ACF block', function () {
+            allow('function_exists')->toBeCalled()->andReturn('true');
+            allow('acf_register_block_type')->toBeCalled();
+            allow('plugin_dir_path')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks');
+            expect('acf_register_block_type')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->accordion->registerBlock();
+        });
+    });
+
+    describe('->registerFields()', function () {
+        it('adds the fields', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_add_local_field_group')->toBeCalled();
+            expect('acf_add_local_field_group')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->accordion->registerFields();
+        });
+    });
+
+    describe('->render()', function () {
+        it('increments the count property by 1 each time it is called', function () {
+            expect($this->accordion->count)->toEqual(0);
+            allow('load_template')->toBeCalled();
+            allow('dirname')->toBeCalled();
+            allow('plugin_dir_path')->toBeCalled();
+            $this->accordion->render();
+            expect($this->accordion->count)->toEqual(1);
+            $this->accordion->render();
+            expect($this->accordion->count)->toEqual(2);
+        });
+        it('calls load_template with the path to the template, and the count value as an argument', function () {
+            allow('plugin_dir_path')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks');
+            allow('dirname')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin');
+            expect('dirname')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks', 2);
+            allow('load_template')->toBeCalled();
+            expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->accordion->templatePath, false, [
+                'govuk-components-accordion-count' => 1
+            ]);
+            $this->accordion->render();
+        });
+    });
+});

--- a/templates/accordion.php
+++ b/templates/accordion.php
@@ -5,20 +5,20 @@ $rowCount = 0;
 
 ?>
 
-<div class="govuk-accordion" data-module="govuk-accordion" id="<?php echo $accordionId ?>">
+<div class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion') ?>" data-module="govuk-accordion" id="<?php echo $accordionId ?>">
     <?php if (have_rows('accordion_sections')) :
-        while (have_rows('accordion_sections')) : the_row(); $rowCount++; 
+        while (have_rows('accordion_sections')) : the_row(); $rowCount++;
         $headingId = $accordionId . '-heading-' . $rowCount;
         ?>
-        <div class="govuk-accordion__section">
-            <div class="govuk-accordion__section-header">
-                <h2 class="govuk-accordion__section-heading">
-                    <span class="govuk-accordion__section-button" id="<?php echo $headingId ?>">
+        <div class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section') ?>">
+            <div class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-header') ?>">
+                <h2 class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-heading') ?>">
+                    <span class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-button') ?>" id="<?php echo $headingId ?>">
                     <?php the_sub_field('accordion_section_heading'); ?>
                     </span>
                 </h2>
             </div>
-            <div id="<?php echo $accordionId ?>-content-<?php echo $rowCount ?>" class="govuk-accordion__section-content" aria-labelledby="<?php echo $headingId ?>">
+            <div id="<?php echo $accordionId ?>-content-<?php echo $rowCount ?>" class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-content') ?>" aria-labelledby="<?php echo $headingId ?>">
                 <?php the_sub_field('accordion_section_content'); ?>
             </div>
         </div>

--- a/templates/accordion.php
+++ b/templates/accordion.php
@@ -1,0 +1,27 @@
+<?php
+
+$accordionId = 'accordion-default-' . $args['govuk-components-accordion-count'];
+$rowCount = 0;
+
+?>
+
+<div class="govuk-accordion" data-module="govuk-accordion" id="<?php echo $accordionId ?>">
+    <?php if (have_rows('accordion_sections')) :
+        while (have_rows('accordion_sections')) : the_row(); $rowCount++; 
+        $headingId = $accordionId . '-heading-' . $rowCount;
+        ?>
+        <div class="govuk-accordion__section">
+            <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                    <span class="govuk-accordion__section-button" id="<?php echo $headingId ?>">
+                    <?php the_sub_field('accordion_section_heading'); ?>
+                    </span>
+                </h2>
+            </div>
+            <div id="<?php echo $accordionId ?>-content-<?php echo $rowCount ?>" class="govuk-accordion__section-content" aria-labelledby="<?php echo $headingId ?>">
+                <?php the_sub_field('accordion_section_content'); ?>
+            </div>
+        </div>
+        <?php endwhile; ?>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
This PR:

- Adds some basic setup for the app (changing the namespace, updating the README)
- Adds the accordion block
- Includes options for filtering the `govuk-` class prefixes output by default
- Adds linting & unit tests to the CI workflow