### PR TITLE
Add Details component

### DIFF
--- a/app/Blocks/Details.php
+++ b/app/Blocks/Details.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace GovukComponents\Blocks;
+
+class Details implements \Dxw\Iguana\Registerable
+{
+    public $templatePath = '/templates/details.php';
+
+    public function register()
+    {
+        add_action('init', [$this, 'registerBlock']);
+        add_action('init', [$this, 'registerFields']);
+    }
+
+    public function registerBlock()
+    {
+        if (function_exists('acf_register_block_type')) {
+            acf_register_block_type([
+                'name'              => 'details',
+                'title'             => 'Details',
+                'render_callback'   => [$this, 'render'],
+                'mode' => 'auto',
+                'category'          => 'formatting',
+                'icon'              => 'arrow-down',
+                'keywords'          => [ 'details', 'accordion' ],
+            ]);
+        }
+    }
+
+    public function registerFields()
+    {
+        if (function_exists('acf_add_local_field_group')):
+
+            acf_add_local_field_group([
+                'key' => 'group_600aa546ee518',
+                'title' => 'Details',
+                'fields' => [
+                    [
+                        'key' => 'field_600aa55198405',
+                        'label' => 'Summary',
+                        'name' => 'details_summary',
+                        'type' => 'text',
+                        'instructions' => '',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'default_value' => '',
+                        'placeholder' => '',
+                        'prepend' => '',
+                        'append' => '',
+                        'maxlength' => '',
+                    ],
+                    [
+                        'key' => 'field_600aa57398406',
+                        'label' => 'Text',
+                        'name' => 'details_text',
+                        'type' => 'textarea',
+                        'instructions' => '',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'default_value' => '',
+                        'placeholder' => '',
+                        'maxlength' => '',
+                        'rows' => '',
+                        'new_lines' => 'br',
+                    ],
+                ],
+                'location' => [
+                    [
+                        [
+                            'param' => 'block',
+                            'operator' => '==',
+                            'value' => 'acf/details',
+                        ],
+                    ],
+                ],
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ]);
+            
+        endif;
+    }
+
+    public function render()
+    {
+        load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false);
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -1,3 +1,4 @@
 <?php
 
 $registrar->addInstance(new \GovukComponents\Blocks\Accordion());
+$registrar->addInstance(new \GovukComponents\Blocks\Details());

--- a/spec/blocks/details.spec.php
+++ b/spec/blocks/details.spec.php
@@ -1,0 +1,51 @@
+<?php
+
+use Kahlan\Arg;
+
+describe(\GovukComponents\Blocks\Details::class, function () {
+    beforeEach(function () {
+        $this->details = new \GovukComponents\Blocks\Details();
+    });
+
+    it('is registerable', function () {
+        expect($this->details)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the actions', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->details, 'registerBlock']);
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->details, 'registerFields']);
+            $this->details->register();
+        });
+    });
+
+    describe('->registerBlock()', function () {
+        it('registers the block', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_register_block_type')->toBeCalled();
+            expect('acf_register_block_type')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->details->registerBlock();
+        });
+    });
+
+    describe('->registerFields()', function () {
+        it('registers the fields', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_add_local_field_group')->toBeCalled();
+            expect('acf_add_local_field_group')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->details->registerFields();
+        });
+    });
+
+    describe('->render()', function () {
+        it('loads the template', function () {
+            allow('plugin_dir_path')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks');
+            allow('dirname')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin');
+            expect('dirname')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks', 2);
+            allow('load_template')->toBeCalled();
+            expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->details->templatePath);
+            $this->details->render();
+        });
+    });
+});

--- a/templates/details.php
+++ b/templates/details.php
@@ -1,0 +1,10 @@
+<details class="<?php echo apply_filters('govuk_components_class', 'govuk-details') ?>" data-module="govuk-details">
+    <summary class="<?php echo apply_filters('govuk_components_class', 'govuk-details__summary') ?>">
+        <span class="<?php echo apply_filters('govuk_components_class', 'govuk-details__summary-text') ?>">
+            <?php echo wp_kses_post(get_field('details_summary')) ?>
+        </span>
+    </summary>
+    <div class="<?php echo apply_filters('govuk_components_class', 'govuk-details__text') ?>">
+        <?php echo wp_kses_post(get_field('details_text')) ?>
+    </div>
+</details>


### PR DESCRIPTION
The govuk Frontend docs (https://design-system.service.gov.uk/components/details/) suggest that the text should only ever be a single para, so I've just used a textarea for that, rather than a full wysiwyg.

Resolves: https://trello.com/c/9F2NdieC/21-add-details-component-to-plugin

<img width="316" alt="Screenshot 2021-01-22 at 10 52 29" src="https://user-images.githubusercontent.com/370665/105482176-eff07200-5c9f-11eb-955e-49f54ce65a75.png">