### PR TITLE
Add inset text block

### DIFF
--- a/app/Blocks/InsetText.php
+++ b/app/Blocks/InsetText.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace GovukComponents\Blocks;
+
+class InsetText implements \Dxw\Iguana\Registerable
+{
+    public $templatePath = '/templates/inset_text.php';
+
+    public function register()
+    {
+        add_action('init', [$this, 'registerBlock']);
+        add_action('init', [$this, 'registerFields']);
+    }
+
+    public function registerBlock()
+    {
+        if (function_exists('acf_register_block_type')) {
+            acf_register_block_type([
+                'name'              => 'inset_text',
+                'title'             => 'Inset Text',
+                'render_callback'   => [$this, 'render'],
+                'mode' => 'auto',
+                'category'          => 'formatting',
+                'icon'              => 'align-pull-left',
+                'keywords'          => [ 'inset', 'highlight', 'text', 'indent' ],
+            ]);
+        }
+    }
+
+    public function registerFields()
+    {
+        if (function_exists('acf_add_local_field_group')):
+
+            acf_add_local_field_group([
+                'key' => 'group_600abb1ff000d',
+                'title' => 'Inset text',
+                'fields' => [
+                    [
+                        'key' => 'field_600abb25cb82c',
+                        'label' => 'Text',
+                        'name' => 'inset_text_text',
+                        'type' => 'textarea',
+                        'instructions' => '',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'default_value' => '',
+                        'placeholder' => '',
+                        'maxlength' => '',
+                        'rows' => '',
+                        'new_lines' => '',
+                    ],
+                ],
+                'location' => [
+                    [
+                        [
+                            'param' => 'block',
+                            'operator' => '==',
+                            'value' => 'acf/inset-text',
+                        ],
+                    ],
+                ],
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ]);
+            
+        endif;
+    }
+
+    public function render()
+    {
+        load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false);
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -2,3 +2,4 @@
 
 $registrar->addInstance(new \GovukComponents\Blocks\Accordion());
 $registrar->addInstance(new \GovukComponents\Blocks\Details());
+$registrar->addInstance(new \GovukComponents\Blocks\InsetText());

--- a/spec/blocks/inset_text.spec.php
+++ b/spec/blocks/inset_text.spec.php
@@ -1,0 +1,51 @@
+<?php
+
+use Kahlan\Arg;
+
+describe(\GovukComponents\Blocks\InsetText::class, function () {
+    beforeEach(function () {
+        $this->insetText = new \GovukComponents\Blocks\InsetText();
+    });
+
+    it('is registerable', function () {
+        expect($this->insetText)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the actions', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->insetText, 'registerBlock']);
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->insetText, 'registerFields']);
+            $this->insetText->register();
+        });
+    });
+
+    describe('->registerBlock()', function () {
+        it('adds the block', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_register_block_type')->toBeCalled();
+            expect('acf_register_block_type')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->insetText->registerBlock();
+        });
+    });
+
+    describe('->registerFields()', function () {
+        it('registers the fields', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_add_local_field_group')->toBeCalled();
+            expect('acf_add_local_field_group')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->insetText->registerFields();
+        });
+    });
+
+    describe('->render()', function () {
+        it('loads the template', function () {
+            allow('plugin_dir_path')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks');
+            allow('dirname')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin');
+            expect('dirname')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks', 2);
+            allow('load_template')->toBeCalled();
+            expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->insetText->templatePath);
+            $this->insetText->render();
+        });
+    });
+});

--- a/templates/inset_text.php
+++ b/templates/inset_text.php
@@ -1,0 +1,3 @@
+<div class="<?php echo apply_filters('govuk_components_class', 'govuk-inset-text') ?>">
+  <?php echo wp_kses_post(get_field('inset_text_text')); ?>
+</div>


### PR DESCRIPTION
<img width="329" alt="Screenshot 2021-01-22 at 11 56 22" src="https://user-images.githubusercontent.com/370665/105487977-dc95d480-5ca8-11eb-8cfe-40decfdcf974.png">

The govuk frontend docs (https://design-system.service.gov.uk/components/inset-text/) show this as a being a small piece of unformatted text, so I've used a textarea rather than a wysiwyg.

Resolves: https://trello.com/c/MW0eIIHd/22-add-inset-text-to-plugin