### PR TITLE
Add Notification Banner block

### DIFF
--- a/app/Blocks/NotificationBanner.php
+++ b/app/Blocks/NotificationBanner.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace GovukComponents\Blocks;
+
+class NotificationBanner implements \Dxw\Iguana\Registerable
+{
+    public $templatePath = '/templates/notification_banner.php';
+
+    public $count = 0;
+
+    public function register()
+    {
+        add_action('init', [$this, 'registerBlock']);
+        add_action('init', [$this, 'registerFields']);
+    }
+
+    public function registerBlock()
+    {
+        if (function_exists('acf_register_block_type')) {
+            acf_register_block_type([
+                'name'              => 'notification_banner',
+                'title'             => 'Notification Banner',
+                'render_callback'   => [$this, 'render'],
+                'mode' => 'auto',
+                'category'          => 'formatting',
+                'icon'              => 'info',
+                'keywords'          => [ 'notification', 'banner' ],
+            ]);
+        }
+    }
+
+    public function registerFields()
+    {
+        if (function_exists('acf_add_local_field_group')):
+
+            acf_add_local_field_group([
+                'key' => 'group_600acaec166e4',
+                'title' => 'Notification Banner',
+                'fields' => [
+                    [
+                        'key' => 'field_600acaf76848d',
+                        'label' => 'Title',
+                        'name' => 'notification_banner_title',
+                        'type' => 'text',
+                        'instructions' => '',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'default_value' => '',
+                        'placeholder' => '',
+                        'maxlength' => '',
+                    ],
+                    [
+                        'key' => 'field_600acaf96248d',
+                        'label' => 'Text',
+                        'name' => 'notification_banner_text',
+                        'type' => 'textarea',
+                        'instructions' => '',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'default_value' => '',
+                        'placeholder' => '',
+                        'maxlength' => '',
+                        'rows' => '',
+                        'new_lines' => 'br',
+                    ],
+                ],
+                'location' => [
+                    [
+                        [
+                            'param' => 'block',
+                            'operator' => '==',
+                            'value' => 'acf/notification-banner',
+                        ],
+                    ],
+                ],
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ]);
+            
+        endif;
+    }
+
+    public function render()
+    {
+        $this->count = $this->count + 1;
+        load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false, [
+            'govuk-components-notification-banner-count' => $this->count
+        ]);
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -3,3 +3,4 @@
 $registrar->addInstance(new \GovukComponents\Blocks\Accordion());
 $registrar->addInstance(new \GovukComponents\Blocks\Details());
 $registrar->addInstance(new \GovukComponents\Blocks\InsetText());
+$registrar->addInstance(new \GovukComponents\Blocks\NotificationBanner());

--- a/spec/blocks/notification_banner.spec.php
+++ b/spec/blocks/notification_banner.spec.php
@@ -1,0 +1,63 @@
+<?php
+
+use Kahlan\Arg;
+
+describe(\GovukComponents\Blocks\NotificationBanner::class, function () {
+    beforeEach(function () {
+        $this->notificationBanner = new \GovukComponents\Blocks\NotificationBanner();
+    });
+
+    it('is registerable', function () {
+        expect($this->notificationBanner)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the actions', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->notificationBanner, 'registerBlock']);
+            expect('add_action')->toBeCalled()->once()->with('init', [$this->notificationBanner, 'registerFields']);
+            $this->notificationBanner->register();
+        });
+    });
+
+    describe('->registerBlock', function () {
+        it('registers the block', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_register_block_type')->toBeCalled();
+            expect('acf_register_block_type')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->notificationBanner->registerBlock();
+        });
+    });
+
+    describe('->registerFields()', function () {
+        it('registers the fields', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_add_local_field_group')->toBeCalled();
+            expect('acf_add_local_field_group')->toBeCalled()->once()->with(Arg::toBeAn('array'));
+            $this->notificationBanner->registerFields();
+        });
+    });
+
+    describe('->render()', function () {
+        it('increments the count value by one', function () {
+            expect($this->notificationBanner->count)->toEqual(0);
+            allow('plugin_dir_path')->toBeCalled();
+            allow('dirname')->toBeCalled();
+            allow('load_template')->toBeCalled();
+            $this->notificationBanner->render();
+            expect($this->notificationBanner->count)->toEqual(1);
+            $this->notificationBanner->render();
+            expect($this->notificationBanner->count)->toEqual(2);
+        });
+        it('loads the template and passes the count of banners rendered', function () {
+            allow('plugin_dir_path')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks');
+            allow('dirname')->toBeCalled()->andReturn('/path/to/wp-content/plugins/govuk-components-plugin');
+            expect('dirname')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin/app/Blocks', 2);
+            allow('load_template')->toBeCalled();
+            expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->notificationBanner->templatePath, false, [
+                'govuk-components-notification-banner-count' => 1
+            ]);
+            $this->notificationBanner->render();
+        });
+    });
+});

--- a/templates/notification_banner.php
+++ b/templates/notification_banner.php
@@ -1,0 +1,16 @@
+<?php
+
+$bannerHeadingId = 'govuk-notification-banner-' . $args['govuk-components-notification-banner-count'] . '-title';
+ ?>
+<div class="<?php echo apply_filters('govuk_components_class', 'govuk-notification-banner') ?>" role="region" aria-labelledby="<?php echo $bannerHeadingId ?>" data-module="govuk-notification-banner">
+  <div class="<?php echo apply_filters('govuk_components_class', 'govuk-notification-banner__header') ?>">
+    <h2 class="<?php echo apply_filters('govuk_components_class', 'govuk-notification-banner__title') ?>" id="<?php echo $bannerHeadingId ?>">
+      <?php echo wp_kses_post(get_field('notification_banner_title')); ?>
+    </h2>
+  </div>
+  <div class="<?php echo apply_filters('govuk_components_class', 'govuk-notification-banner__content') ?>">
+    <p class="<?php echo apply_filters('govuk_components_class', 'govuk-notification-banner__heading') ?>">
+      <?php echo wp_kses_post(get_field('notification_banner_text')); ?>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
<img width="1001" alt="Screenshot 2021-01-22 at 15 14 57" src="https://user-images.githubusercontent.com/370665/105508699-99495f00-5cc4-11eb-94e9-03eb4f7c823c.png">

Because the `<p>` tags within the banner require their own specific class, I've opted to make that a textarea rather than a wysiwyg for now.

That means that they'll only be plain text (unless you add the HTML for a link), but I think that's ok for now. We can always revisit if needed.

Resolves: https://trello.com/c/7qyeExDS/23-add-notification-banner-to-plugin