### PR TITLE
Strip scripts from accordion title output

### DIFF
--- a/templates/accordion.php
+++ b/templates/accordion.php
@@ -14,7 +14,7 @@ $rowCount = 0;
             <div class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-header') ?>">
                 <h2 class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-heading') ?>">
                     <span class="<?php echo apply_filters('govuk_components_class', 'govuk-accordion__section-button') ?>" id="<?php echo $headingId ?>">
-                    <?php the_sub_field('accordion_section_heading'); ?>
+                    <?php echo wp_kses_post(get_sub_field('accordion_section_heading')); ?>
                     </span>
                 </h2>
             </div>


### PR DESCRIPTION
Before: it was possible to inject script into the page via the accordion title field. Wysiwyg fields get auto-escaped on save, but plain text fields don't.

Now: wp_kses_post() is used in the template to prevent this.