### PR TITLE
Feature/30 allow admins to toggle component blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Warning Text block
+- Option for admins to each block type on or off on a site-wide basis
 
 ## [0.1.0] - 2021-01-26
 

--- a/app/BlockController.php
+++ b/app/BlockController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace GovukComponents;
+
+class BlockController
+{
+    private $blocks;
+
+    public function __construct(array $blocks)
+    {
+        $this->blocks = $blocks;
+    }
+
+    public function getAvailableBlockOptions()
+    {
+        $options = [];
+        foreach ($this->blocks as $block) {
+            $options[$block->getOptionName()] = $block->getDisplayName();
+        }
+        return $options;
+    }
+
+    public function getDefaultBlockOptions()
+    {
+        $options = [];
+        foreach ($this->blocks as $block) {
+            $options[] = $block->getOptionName();
+        }
+        return $options;
+    }
+
+    public function activateBlocks($blockOptionNames)
+    {
+        foreach ($this->blocks as $block) {
+            if (in_array($block->getOptionName(), $blockOptionNames)) {
+                $block->init();
+            }
+        }
+    }
+}

--- a/app/Blocks/Accordion.php
+++ b/app/Blocks/Accordion.php
@@ -2,14 +2,20 @@
 
 namespace GovukComponents\Blocks;
 
-class Accordion implements \Dxw\Iguana\Registerable
+class Accordion implements iBlock
 {
     /* the path to the template for this block from the root of the plugin */
     public $templatePath = '/templates/accordion.php';
 
     public $count = 0;
 
-    public function register()
+    protected const DISPLAY_NAME = 'Accordion';
+
+    /* NOTE: changing this could affect which */
+    /* components a user has activated */
+    protected const OPTION_NAME = 'accordion';
+
+    public function init()
     {
         add_action('init', [$this, 'registerBlock']);
         add_action('init', [$this, 'registerFields']);
@@ -126,5 +132,15 @@ class Accordion implements \Dxw\Iguana\Registerable
         load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false, [
             'govuk-components-accordion-count' => $this->count
         ]);
+    }
+
+    public function getDisplayName() : string
+    {
+        return self::DISPLAY_NAME;
+    }
+
+    public function getOptionName() : string
+    {
+        return self::OPTION_NAME;
     }
 }

--- a/app/Blocks/Button.php
+++ b/app/Blocks/Button.php
@@ -2,12 +2,18 @@
 
 namespace GovukComponents\Blocks;
 
-class Button implements \Dxw\Iguana\Registerable
+class Button implements iBlock
 {
     /* the path to the template for this block from the root of the plugin */
     public $templatePath = '/templates/button.php';
 
-    public function register()
+    protected const DISPLAY_NAME = 'Button';
+
+    /* NOTE: changing this could affect which */
+    /* components a user has activated */
+    protected const OPTION_NAME = 'button';
+
+    public function init()
     {
         add_action('init', [$this, 'registerBlock']);
         add_action('init', [$this, 'registerFields']);
@@ -95,5 +101,15 @@ class Button implements \Dxw\Iguana\Registerable
     public function render()
     {
         load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false);
+    }
+
+    public function getDisplayName() : string
+    {
+        return self::DISPLAY_NAME;
+    }
+
+    public function getOptionName() : string
+    {
+        return self::OPTION_NAME;
     }
 }

--- a/app/Blocks/Details.php
+++ b/app/Blocks/Details.php
@@ -2,11 +2,17 @@
 
 namespace GovukComponents\Blocks;
 
-class Details implements \Dxw\Iguana\Registerable
+class Details implements iBlock
 {
+    protected const DISPLAY_NAME = 'Details';
+
+    /* NOTE: changing this could affect which */
+    /* components a user has activated */
+    protected const OPTION_NAME = 'details';
+
     public $templatePath = '/templates/details.php';
 
-    public function register()
+    public function init()
     {
         add_action('init', [$this, 'registerBlock']);
         add_action('init', [$this, 'registerFields']);
@@ -99,5 +105,15 @@ class Details implements \Dxw\Iguana\Registerable
     public function render()
     {
         load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false);
+    }
+
+    public function getOptionName() : string
+    {
+        return self::OPTION_NAME;
+    }
+
+    public function getDisplayName(): string
+    {
+        return self::DISPLAY_NAME;
     }
 }

--- a/app/Blocks/InsetText.php
+++ b/app/Blocks/InsetText.php
@@ -2,11 +2,17 @@
 
 namespace GovukComponents\Blocks;
 
-class InsetText implements \Dxw\Iguana\Registerable
+class InsetText implements iBlock
 {
     public $templatePath = '/templates/inset_text.php';
 
-    public function register()
+    protected const DISPLAY_NAME = 'Inset Text';
+
+    /* NOTE: changing this could affect which */
+    /* components a user has activated */
+    protected const OPTION_NAME = 'inset_text';
+
+    public function init()
     {
         add_action('init', [$this, 'registerBlock']);
         add_action('init', [$this, 'registerFields']);
@@ -80,5 +86,15 @@ class InsetText implements \Dxw\Iguana\Registerable
     public function render()
     {
         load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false);
+    }
+
+    public function getDisplayName() : string
+    {
+        return self::DISPLAY_NAME;
+    }
+
+    public function getOptionName(): string
+    {
+        return self::OPTION_NAME;
     }
 }

--- a/app/Blocks/NotificationBanner.php
+++ b/app/Blocks/NotificationBanner.php
@@ -2,13 +2,19 @@
 
 namespace GovukComponents\Blocks;
 
-class NotificationBanner implements \Dxw\Iguana\Registerable
+class NotificationBanner implements iBlock
 {
     public $templatePath = '/templates/notification_banner.php';
 
     public $count = 0;
 
-    public function register()
+    protected const DISPLAY_NAME = 'Notification Banner';
+
+    /* NOTE: changing this could affect which */
+    /* components a user has activated */
+    protected const OPTION_NAME = 'notification_banner';
+
+    public function init()
     {
         add_action('init', [$this, 'registerBlock']);
         add_action('init', [$this, 'registerFields']);
@@ -102,5 +108,15 @@ class NotificationBanner implements \Dxw\Iguana\Registerable
         load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false, [
             'govuk-components-notification-banner-count' => $this->count
         ]);
+    }
+
+    public function getDisplayName() : string
+    {
+        return self::DISPLAY_NAME;
+    }
+
+    public function getOptionName(): string
+    {
+        return self::OPTION_NAME;
     }
 }

--- a/app/Blocks/WarningText.php
+++ b/app/Blocks/WarningText.php
@@ -2,11 +2,17 @@
 
 namespace GovukComponents\Blocks;
 
-class WarningText implements \Dxw\Iguana\Registerable
+class WarningText implements iBlock
 {
     public $templatePath = '/templates/warning_text.php';
 
-    public function register()
+    protected const DISPLAY_NAME = "Warning Text";
+
+    /* NOTE: changing this could affect which */
+    /* components a user has activated */
+    protected const OPTION_NAME = 'warning_text';
+
+    public function init()
     {
         add_action('init', [$this, 'registerBlock']);
         add_action('init', [$this, 'registerFields']);
@@ -80,5 +86,15 @@ class WarningText implements \Dxw\Iguana\Registerable
     public function render()
     {
         load_template(dirname(plugin_dir_path(__FILE__), 2) . $this->templatePath, false);
+    }
+
+    public function getDisplayName() : string
+    {
+        return self::DISPLAY_NAME;
+    }
+
+    public function getOptionName() : string
+    {
+        return self::OPTION_NAME;
     }
 }

--- a/app/Blocks/iBlock.php
+++ b/app/Blocks/iBlock.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace GovukComponents\Blocks;
+
+interface iBlock
+{
+    public function init();
+
+    public function getDisplayName() : string;
+
+    public function getOptionName() : string;
+}

--- a/app/Options.php
+++ b/app/Options.php
@@ -84,6 +84,9 @@ class Options implements \Dxw\Iguana\Registerable
     public function apply()
     {
         $activeBlocks = get_field('govuk_components_enable_component_blocks', 'option');
+        if (is_null($activeBlocks)) {
+            $activeBlocks = $this->blockController->getDefaultBlockOptions();
+        }
         $this->blockController->activateBlocks($activeBlocks);
     }
 }

--- a/app/Options.php
+++ b/app/Options.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace GovukComponents;
+
+class Options implements \Dxw\Iguana\Registerable
+{
+    private $blockController;
+
+    public function __construct(BlockController $blockController)
+    {
+        $this->blockController = $blockController;
+    }
+
+    public function register()
+    {
+        add_action('acf/init', [$this, 'addPage']);
+        add_action('acf/init', [$this, 'registerOptions']);
+        add_action('acf/init', [$this, 'apply']);
+    }
+
+    public function addPage()
+    {
+        if (function_exists('acf_add_options_page')) {
+            acf_add_options_page([
+                'page_title' => 'GOV.UK Components',
+                'capability' => 'edit_users',
+                'parent_slug' => 'options-general.php'
+            ]);
+        }
+    }
+
+    public function registerOptions()
+    {
+        if (function_exists('acf_add_local_field_group')):
+
+            acf_add_local_field_group([
+                'key' => 'group_60117c47385e6',
+                'title' => 'Options',
+                'fields' => [
+                    [
+                        'key' => 'field_60117c7564efc',
+                        'label' => 'Enable component blocks',
+                        'name' => 'govuk_components_enable_component_blocks',
+                        'type' => 'checkbox',
+                        'instructions' => 'Tick the checkboxes for the component blocks you would like available in the block editor.',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'choices' => $this->blockController->getAvailableBlockOptions(),
+                        'allow_custom' => 0,
+                        'default_value' => $this->blockController->getDefaultBlockOptions(),
+                        'layout' => 'vertical',
+                        'toggle' => 0,
+                        'return_format' => 'value',
+                        'save_custom' => 0,
+                    ],
+                ],
+                'location' => [
+                    [
+                        [
+                            'param' => 'options_page',
+                            'operator' => '==',
+                            'value' => 'acf-options-gov-uk-components',
+                        ],
+                    ],
+                ],
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+            ]);
+            
+        endif;
+    }
+
+    public function apply()
+    {
+        $activeBlocks = get_field('govuk_components_enable_component_blocks', 'option');
+        $this->blockController->activateBlocks($activeBlocks);
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -6,3 +6,18 @@ $registrar->addInstance(new \GovukComponents\Blocks\Details());
 $registrar->addInstance(new \GovukComponents\Blocks\InsetText());
 $registrar->addInstance(new \GovukComponents\Blocks\NotificationBanner());
 $registrar->addInstance(new \GovukComponents\Blocks\WarningText());
+
+$registrar->addInstance(new \GovukComponents\BlockController(
+    [
+        $registrar->getInstance(\GovukComponents\Blocks\Accordion::class),
+        $registrar->getInstance(\GovukComponents\Blocks\Button::class),
+        $registrar->getInstance(\GovukComponents\Blocks\Details::class),
+        $registrar->getInstance(\GovukComponents\Blocks\InsetText::class),
+        $registrar->getInstance(\GovukComponents\Blocks\NotificationBanner::class),
+        $registrar->getInstance(\GovukComponents\Blocks\WarningText::class)
+    ]
+));
+
+$registrar->addInstance(new \GovukComponents\Options(
+    $registrar->getInstance(\GovukComponents\BlockController::class)
+));

--- a/spec/block_controller.spec.php
+++ b/spec/block_controller.spec.php
@@ -1,0 +1,63 @@
+<?php
+
+use Kahlan\Arg;
+use Kahlan\Matcher\ToReceive;
+use Kahlan\Plugin\Double;
+
+describe(\GovukComponents\BlockController::class, function () {
+    beforeEach(function () {
+        $this->block1 = Double::instance(
+            ['implements' => 'GovukComponents\Blocks\iBlock']
+        );
+        $this->block2 = Double::instance(
+            ['implements' => 'GovukComponents\Blocks\iBlock']
+        );
+        allow($this->block1)->toReceive('getOptionName')->andReturn('foo_bar');
+        allow($this->block1)->toReceive('getDisplayName')->andReturn('Foo Bar');
+        allow($this->block2)->toReceive('getOptionName')->andReturn('dumb_struck');
+        allow($this->block2)->toReceive('getDisplayName')->andReturn('Dumb Struck');
+        $this->blockController = new \GovukComponents\BlockController([
+            $this->block1,
+            $this->block2
+        ]);
+    });
+
+    describe('->getAvailableBlockOptions()', function () {
+        it('returns a key-value array of the blocks, where the key is the block OPTION_NAME, and the value the DISPLAY_NAME', function () {
+            $result = $this->blockController->getAvailableBlockOptions();
+            expect($result)->toEqual([
+                'foo_bar' => 'Foo Bar',
+                'dumb_struck' => 'Dumb Struck'
+            ]);
+        });
+    });
+
+    describe('->getDefaultBlockOptions()', function () {
+        it('returns a numerically indexed array of the blocks ordered as injected, where each value is the block OPTION_NAME', function () {
+            $result = $this->blockController->getDefaultBlockOptions();
+            expect($result)->toEqual([
+                0 => 'foo_bar',
+                1 => 'dumb_struck'
+            ]);
+        });
+    });
+
+    describe('->activateBlocks()', function () {
+        it('calls the init() method of each block that has an option matching a value in the array it is given', function () {
+            allow($this->block1)->toReceive('init');
+            expect($this->block1)->toReceive('init')->once();
+            $this->blockController->activateBlocks([
+                'foo_bar',
+            ]);
+        });
+        it('does not call the init() method of blocks that do not have an option matching a value in the array it is given', function () {
+            allow($this->block1)->toReceive('init');
+            allow($this->block2)->toReceive('init');
+            expect($this->block1)->not->toReceive('init');
+            expect($this->block2)->toReceive('init')->once();
+            $this->blockController->activateBlocks([
+                'dumb_struck',
+            ]);
+        });
+    });
+});

--- a/spec/blocks/accordion.spec.php
+++ b/spec/blocks/accordion.spec.php
@@ -7,16 +7,16 @@ describe(\GovukComponents\Blocks\Accordion::class, function () {
         $this->accordion = new \GovukComponents\Blocks\Accordion();
     });
 
-    it('is registerable', function () {
-        expect($this->accordion)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    it('implements iBlock', function () {
+        expect($this->accordion)->toBeAnInstanceOf(\GovukComponents\Blocks\iBlock::class);
     });
 
-    describe('->register()', function () {
+    describe('->init()', function () {
         it('adds the actions', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->accordion, 'registerBlock']);
             expect('add_action')->toBeCalled()->once()->with('init', [$this->accordion, 'registerFields']);
-            $this->accordion->register();
+            $this->accordion->init();
         });
     });
 
@@ -59,6 +59,18 @@ describe(\GovukComponents\Blocks\Accordion::class, function () {
                 'govuk-components-accordion-count' => 1
             ]);
             $this->accordion->render();
+        });
+    });
+
+    describe('->getOptionName()', function () {
+        it('returns the option name', function () {
+            expect($this->accordion->getOptionName())->toEqual('accordion');
+        });
+    });
+
+    describe('->getDisplayName()', function () {
+        it('returns a string', function () {
+            expect($this->accordion->getDisplayName())->toBeA('string');
         });
     });
 });

--- a/spec/blocks/button.spec.php
+++ b/spec/blocks/button.spec.php
@@ -7,16 +7,16 @@ describe(\GovukComponents\Blocks\Button::class, function () {
         $this->button = new \GovukComponents\Blocks\Button();
     });
 
-    it('is registerable', function () {
-        expect($this->button)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    it('implements iBlock', function () {
+        expect($this->button)->toBeAnInstanceOf(\GovukComponents\Blocks\iBlock::class);
     });
 
-    describe('->register()', function () {
+    describe('->init()', function () {
         it('adds the actions', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->button, 'registerBlock']);
             expect('add_action')->toBeCalled()->once()->with('init', [$this->button, 'registerFields']);
-            $this->button->register();
+            $this->button->init();
         });
     });
 
@@ -47,6 +47,18 @@ describe(\GovukComponents\Blocks\Button::class, function () {
             allow('load_template')->toBeCalled();
             expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->button->templatePath, false);
             $this->button->render();
+        });
+    });
+
+    describe('->getOptionName()', function () {
+        it('returns the option name', function () {
+            expect($this->button->getOptionName())->toEqual('button');
+        });
+    });
+
+    describe('->getDisplayName()', function () {
+        it('returns a string', function () {
+            expect($this->button->getDisplayName())->toBeA('string');
         });
     });
 });

--- a/spec/blocks/details.spec.php
+++ b/spec/blocks/details.spec.php
@@ -7,16 +7,16 @@ describe(\GovukComponents\Blocks\Details::class, function () {
         $this->details = new \GovukComponents\Blocks\Details();
     });
 
-    it('is registerable', function () {
-        expect($this->details)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    it('implements iBlock', function () {
+        expect($this->details)->toBeAnInstanceOf(\GovukComponents\Blocks\iBlock::class);
     });
 
-    describe('->register()', function () {
+    describe('->init()', function () {
         it('adds the actions', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->details, 'registerBlock']);
             expect('add_action')->toBeCalled()->once()->with('init', [$this->details, 'registerFields']);
-            $this->details->register();
+            $this->details->init();
         });
     });
 
@@ -46,6 +46,18 @@ describe(\GovukComponents\Blocks\Details::class, function () {
             allow('load_template')->toBeCalled();
             expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->details->templatePath, false);
             $this->details->render();
+        });
+    });
+
+    describe('->getOptionName()', function () {
+        it('returns the option name', function () {
+            expect($this->details->getOptionName())->toEqual('details');
+        });
+    });
+
+    describe('->getDisplayName()', function () {
+        it('returns a string', function () {
+            expect($this->details->getDisplayName())->toBeA('string');
         });
     });
 });

--- a/spec/blocks/inset_text.spec.php
+++ b/spec/blocks/inset_text.spec.php
@@ -7,16 +7,16 @@ describe(\GovukComponents\Blocks\InsetText::class, function () {
         $this->insetText = new \GovukComponents\Blocks\InsetText();
     });
 
-    it('is registerable', function () {
-        expect($this->insetText)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    it('implements iBlock', function () {
+        expect($this->insetText)->toBeAnInstanceOf(\GovukComponents\Blocks\iBlock::class);
     });
 
-    describe('->register()', function () {
+    describe('->init()', function () {
         it('adds the actions', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->insetText, 'registerBlock']);
             expect('add_action')->toBeCalled()->once()->with('init', [$this->insetText, 'registerFields']);
-            $this->insetText->register();
+            $this->insetText->init();
         });
     });
 
@@ -46,6 +46,18 @@ describe(\GovukComponents\Blocks\InsetText::class, function () {
             allow('load_template')->toBeCalled();
             expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->insetText->templatePath, false);
             $this->insetText->render();
+        });
+    });
+
+    describe('->getOptionName()', function () {
+        it('returns the option name', function () {
+            expect($this->insetText->getOptionName())->toEqual('inset_text');
+        });
+    });
+
+    describe('->getDisplayName()', function () {
+        it('returns a string', function () {
+            expect($this->insetText->getDisplayName())->toBeA('string');
         });
     });
 });

--- a/spec/blocks/notification_banner.spec.php
+++ b/spec/blocks/notification_banner.spec.php
@@ -7,16 +7,16 @@ describe(\GovukComponents\Blocks\NotificationBanner::class, function () {
         $this->notificationBanner = new \GovukComponents\Blocks\NotificationBanner();
     });
 
-    it('is registerable', function () {
-        expect($this->notificationBanner)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    it('implements iBlock', function () {
+        expect($this->notificationBanner)->toBeAnInstanceOf(GovukComponents\Blocks\iBlock::class);
     });
 
-    describe('->register()', function () {
+    describe('->init()', function () {
         it('adds the actions', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->notificationBanner, 'registerBlock']);
             expect('add_action')->toBeCalled()->once()->with('init', [$this->notificationBanner, 'registerFields']);
-            $this->notificationBanner->register();
+            $this->notificationBanner->init();
         });
     });
 
@@ -58,6 +58,18 @@ describe(\GovukComponents\Blocks\NotificationBanner::class, function () {
                 'govuk-components-notification-banner-count' => 1
             ]);
             $this->notificationBanner->render();
+        });
+    });
+
+    describe('->getOptionName()', function () {
+        it('returns the option name', function () {
+            expect($this->notificationBanner->getOptionName())->toEqual('notification_banner');
+        });
+    });
+
+    describe('->getDisplayName()', function () {
+        it('returns a string', function () {
+            expect($this->notificationBanner->getDisplayName())->toBeA('string');
         });
     });
 });

--- a/spec/blocks/warning_text.spec.php
+++ b/spec/blocks/warning_text.spec.php
@@ -7,16 +7,16 @@ describe(\GovukComponents\Blocks\WarningText::class, function () {
         $this->warningText = new \GovukComponents\Blocks\WarningText();
     });
 
-    it('is registerable', function () {
-        expect($this->warningText)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    it('implements iBlock', function () {
+        expect($this->warningText)->toBeAnInstanceOf(\GovukComponents\Blocks\iBlock::class);
     });
 
-    describe('->register()', function () {
+    describe('->init()', function () {
         it('adds the actions', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->warningText, 'registerBlock']);
             expect('add_action')->toBeCalled()->once()->with('init', [$this->warningText, 'registerFields']);
-            $this->warningText->register();
+            $this->warningText->init();
         });
     });
 
@@ -46,6 +46,18 @@ describe(\GovukComponents\Blocks\WarningText::class, function () {
             allow('load_template')->toBeCalled();
             expect('load_template')->toBeCalled()->once()->with('/path/to/wp-content/plugins/govuk-components-plugin' . $this->warningText->templatePath, false);
             $this->warningText->render();
+        });
+    });
+
+    describe('->getOptionName()', function () {
+        it('returns the option name', function () {
+            expect($this->warningText->getOptionName())->toEqual('warning_text');
+        });
+    });
+
+    describe('->getDisplayName()', function () {
+        it('returns a string', function () {
+            expect($this->warningText->getDisplayName())->toBeA('string');
         });
     });
 });

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -59,18 +59,37 @@ describe(\GovukComponents\Options::class, function () {
     });
 
     describe('->apply()', function () {
-        it('calls the BlockController with a list of the plugins to activate', function () {
-            allow('get_field')->toBeCalled()->andReturn([
-                'enabled_block_option_name_1',
-                'enabled_block_option_name_2'
-            ]);
-            expect('get_field')->toBeCalled()->once()->with('govuk_components_enable_component_blocks', 'option');
-            allow($this->blockController)->toReceive('activateBlocks');
-            expect($this->blockController)->toReceive('activateBlocks')->once()->with([
-                'enabled_block_option_name_1',
-                'enabled_block_option_name_2'
-            ]);
-            $this->options->apply();
+        context('the options have been saved', function () {
+            it('calls the BlockController with a list of the plugins to activate', function () {
+                allow('get_field')->toBeCalled()->andReturn([
+                    'enabled_block_option_name_1',
+                    'enabled_block_option_name_2'
+                ]);
+                expect('get_field')->toBeCalled()->once()->with('govuk_components_enable_component_blocks', 'option');
+                allow($this->blockController)->toReceive('activateBlocks');
+                expect($this->blockController)->toReceive('activateBlocks')->once()->with([
+                    'enabled_block_option_name_1',
+                    'enabled_block_option_name_2'
+                ]);
+                $this->options->apply();
+            });
+        });
+        context('the options have not been saved (so get_field returns null)', function () {
+            it('returns the list of default block options', function () {
+                allow('get_field')->toBeCalled()->andReturn(null);
+                expect('get_field')->toBeCalled()->once()->with('govuk_components_enable_component_blocks', 'option');
+                allow($this->blockController)->toReceive('getDefaultBlockOptions')->andReturn([
+                    0 => 'default_block_1',
+                    1 =>'default_block_2'
+                ]);
+                expect($this->blockController)->toReceive('getDefaultBlockOptions')->once();
+                allow($this->blockController)->toReceive('activateBlocks');
+                expect($this->blockController)->toReceive('activateBlocks')->once()->with([
+                    0 => 'default_block_1',
+                    1 =>'default_block_2'
+                ]);
+                $this->options->apply();
+            });
         });
     });
 });

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -1,0 +1,76 @@
+<?php
+
+use Kahlan\Arg;
+use Kahlan\Plugin\Double;
+
+describe(\GovukComponents\Options::class, function () {
+    beforeEach(function () {
+        $this->blockController = Double::instance([
+            'extends' => 'GovukComponents\BlockController',
+            'magicMethods' => true
+        ]);
+        $this->options = new \GovukComponents\Options($this->blockController);
+    });
+
+    it('is registerable', function () {
+        expect($this->options)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+        
+    describe('->register()', function () {
+        it('adds the actions', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->times(3);
+            expect('add_action')->toBeCalled()->with('acf/init', [$this->options, 'addPage']);
+            expect('add_action')->toBeCalled()->with('acf/init', [$this->options, 'registerOptions']);
+            expect('add_action')->toBeCalled()->with('acf/init', [$this->options, 'apply']);
+            $this->options->register();
+        });
+    });
+
+    describe('->addPage()', function () {
+        it('adds the options page', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow('acf_add_options_page')->toBeCalled();
+            expect('acf_add_options_page')->toBeCalled()->once();
+            expect('acf_add_options_page')->toBeCalled()->with(Arg::toBeAn('array'));
+            $this->options->addPage();
+        });
+    });
+
+    describe('->registerOptions()', function () {
+        it('adds the options', function () {
+            allow('function_exists')->toBeCalled()->andReturn(true);
+            allow($this->blockController)->toReceive('getAvailableBlockOptions')->andReturn([
+                'block_1_option_name' => 'Block 1 Display Name',
+                'block_2_option_name' => 'Block 2 Display Name'
+            ]);
+            expect($this->blockController)->toReceive('getAvailableBlockOptions')->once();
+            allow($this->blockController)->toReceive('getDefaultBlockOptions')->andReturn([
+                0 => 'block_1_option_name',
+                1 => 'block_2_option_name'
+            ]);
+            expect($this->blockController)->toReceive('getDefaultBlockOptions')->once();
+            allow('acf_add_local_field_group')->toBeCalled();
+            expect('acf_add_local_field_group')->toBeCalled()->once();
+            expect('acf_add_local_field_group')->toBeCalled()->with(Arg::toBeAn('array'));
+            $this->options->registerOptions();
+        });
+    });
+
+    describe('->apply()', function () {
+        it('calls the BlockController with a list of the plugins to activate', function () {
+            allow('get_field')->toBeCalled()->andReturn([
+                'enabled_block_option_name_1',
+                'enabled_block_option_name_2'
+            ]);
+            expect('get_field')->toBeCalled()->once()->with('govuk_components_enable_component_blocks', 'option');
+            allow($this->blockController)->toReceive('activateBlocks');
+            expect($this->blockController)->toReceive('activateBlocks')->once()->with([
+                'enabled_block_option_name_1',
+                'enabled_block_option_name_2'
+            ]);
+            $this->options->apply();
+        });
+    });
+});


### PR DESCRIPTION
This PR adds an options page under "Settings > GOV.UK Components" where admins can toggle each block on or off. The default when first installing the plugin is for all blocks to be active.

To do this in a way that will make adding more blocks an easy process, I've added a couple of new classes:

1) An "Options" class, which is responsible for creating the options page, generating the options on that page, and then applying the selected options to the site; and
2) A "BlockController" class, which all the individual block classes are passed into, which is responsible for generating the list of blocks for which options should be available, and then activating the blocks the "Options" class tells it to.

This should mean that if we want to add more blocks, we just have to add a new Block class and pass it into the BlockController. Everything else will be handled automatically (i.e. we won't have to touch the ACF code generating the options). To assist with this, I've also created an `iBlock` interface to code the blocks against.