### PR TITLE
Added new block Category 'Custom'

### DIFF
--- a/app/BlockCategory.php
+++ b/app/BlockCategory.php
@@ -1,0 +1,30 @@
+<?php
+namespace GovukComponents;
+
+class BlockCategory implements \Dxw\Iguana\Registerable
+{
+    public function register()
+    {
+        add_filter('block_categories', [$this, 'newBlocksCategory'], 10, 1);
+    }
+
+    public function newBlocksCategory($categories)
+    {
+        $block_category = [ 'title' => 'Custom', 'slug' => 'govuk-custom' ];
+        $category_slugs = array_column($categories, 'slug');
+
+        if (! in_array($block_category['slug'], $category_slugs, true)) {
+            $categories = array_merge(
+                [
+                    [
+                        'title' => $block_category['title'],
+                        'slug'  => $block_category['slug'],
+                    ],
+                ],
+                $categories
+            );
+        }
+
+        return $categories;
+    }
+}

--- a/app/Blocks/Accordion.php
+++ b/app/Blocks/Accordion.php
@@ -29,7 +29,7 @@ class Accordion implements iBlock
                 'title'             => 'Accordion',
                 'render_callback'   => [$this, 'render'],
                 'mode' => 'auto',
-                'category'          => 'formatting',
+                'category'          => 'govuk-custom',
                 'icon'              => 'list-view',
                 'keywords'          => [ 'accordion' ],
             ]);

--- a/app/Blocks/Button.php
+++ b/app/Blocks/Button.php
@@ -27,7 +27,7 @@ class Button implements iBlock
                 'title'           => 'Button',
                 'description'     => 'Button',
                 'render_callback' => [$this, 'render'],
-                'category'        => 'formatting',
+                'category'        => 'govuk-custom',
                 'icon'            => 'button',
                 'keywords'        => ['button', 'link'],
                 'mode'            => 'auto',

--- a/app/Blocks/Details.php
+++ b/app/Blocks/Details.php
@@ -26,7 +26,7 @@ class Details implements iBlock
                 'title'             => 'Details',
                 'render_callback'   => [$this, 'render'],
                 'mode' => 'auto',
-                'category'          => 'formatting',
+                'category'          => 'govuk-custom',
                 'icon'              => 'arrow-down',
                 'keywords'          => [ 'details', 'accordion' ],
             ]);

--- a/app/Blocks/InsetText.php
+++ b/app/Blocks/InsetText.php
@@ -26,7 +26,7 @@ class InsetText implements iBlock
                 'title'             => 'Inset Text',
                 'render_callback'   => [$this, 'render'],
                 'mode' => 'auto',
-                'category'          => 'formatting',
+                'category'          => 'govuk-custom',
                 'icon'              => 'align-pull-left',
                 'keywords'          => [ 'inset', 'highlight', 'text', 'indent' ],
             ]);

--- a/app/Blocks/NotificationBanner.php
+++ b/app/Blocks/NotificationBanner.php
@@ -28,7 +28,7 @@ class NotificationBanner implements iBlock
                 'title'             => 'Notification Banner',
                 'render_callback'   => [$this, 'render'],
                 'mode' => 'auto',
-                'category'          => 'formatting',
+                'category'          => 'govuk-custom',
                 'icon'              => 'info',
                 'keywords'          => [ 'notification', 'banner' ],
             ]);

--- a/app/Blocks/WarningText.php
+++ b/app/Blocks/WarningText.php
@@ -26,7 +26,7 @@ class WarningText implements iBlock
                 'title'             => 'Warning Text',
                 'render_callback'   => [$this, 'render'],
                 'mode' => 'auto',
-                'category'          => 'formatting',
+                'category'          => 'govuk-custom',
                 'icon'              => 'warning',
                 'keywords'          => [ 'warning', 'text', 'notification' ],
             ]);

--- a/app/di.php
+++ b/app/di.php
@@ -7,6 +7,8 @@ $registrar->addInstance(new \GovukComponents\Blocks\InsetText());
 $registrar->addInstance(new \GovukComponents\Blocks\NotificationBanner());
 $registrar->addInstance(new \GovukComponents\Blocks\WarningText());
 
+$registrar->addInstance(new \GovukComponents\BlockCategory());
+
 $registrar->addInstance(new \GovukComponents\BlockController(
     [
         $registrar->getInstance(\GovukComponents\Blocks\Accordion::class),

--- a/spec/block_category.spec.php
+++ b/spec/block_category.spec.php
@@ -1,0 +1,86 @@
+<?php
+
+describe(\GovukComponents\BlockCategory::class, function () {
+    beforeEach(function () {
+        $this->blockCategory = new \GovukComponents\BlockCategory();
+    });
+
+    describe('->register()', function () {
+        it('adds the filter', function () {
+            allow('add_filter')->toBeCalled();
+            expect('add_filter')->toBeCalled()->once()->with(
+                'block_categories',
+                [ $this->blockCategory, 'newBlocksCategory' ],
+                10,
+                1
+            );
+            $this->blockCategory->register();
+        });
+    });
+
+    describe('->newBlocksCategory()', function () {
+        context('the new category is not in the array', function () {
+            it('appends a new value to the array, and returns it', function () {
+                $categories = [
+                    [
+                        'slug'  => 'text',
+                        'title' => 'Text'
+                    ],
+                    [
+                        'slug'  => 'media',
+                        'title' => 'Media'
+                    ],
+                    [
+                        'slug'  => 'design',
+                        'title' => 'Design'
+                    ],
+                ];
+
+                $result = $this->blockCategory->newBlocksCategory($categories);
+                expect($result)->toEqual([
+                    [
+                        "title" => "Custom",
+                        "slug"  => "govuk-custom"
+                    ],
+                    [
+                        'slug'  => 'text',
+                        'title' => 'Text'
+                    ],
+                    [
+                        'slug'  => 'media',
+                        'title' => 'Media'
+                    ],
+                    [
+                        'slug'  => 'design',
+                        'title' => 'Design'
+                    ]
+                ]);
+            });
+        });
+        context('the new category is in the array', function () {
+            it('returns the array unchanged', function () {
+                $categories = [
+                    [
+                        "title" => "Custom",
+                        "slug"  => "govuk-custom"
+                    ],
+                    [
+                        'slug'  => 'text',
+                        'title' => 'Text'
+                    ],
+                    [
+                        'slug'  => 'media',
+                        'title' => 'Media'
+                    ],
+                    [
+                        'slug'  => 'design',
+                        'title' => 'Design'
+                    ],
+                ];
+
+                $result = $this->blockCategory->newBlocksCategory($categories);
+                expect($result)->toEqual($categories);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Before: we should give a name to our component blocks so they can be easily identified; it can be gov.uk or design-system (or something like it) for now, eventually, it would be better to not refer to gov.uk or gds. Ideally, we would use the site or client name (or an abbreviated version of it) to indicate that these were *their* blocks.

After: we decided to create a new block category with the slug 'govuk-custom' and the name 'Custom' on top of the other categories, so the component blocks are now visible as a group and easily identified. Ideally in the future we should add an option into the plugin to change the category label with any string: the site name, the client name, etc.

Resolves: https://trello.com/c/JFYxV5ZO/31-name-our-component-blocks-so-they-can-be-identified