### PR TITLE
Feature/block button variation

### DIFF
--- a/app/Scripts.php
+++ b/app/Scripts.php
@@ -6,6 +6,19 @@ class Scripts implements \Dxw\Iguana\Registerable
 {
 	public function register(): void
 	{
-		add_action('enqueue_block_editor_assets', [$this, 'govukComponentsBlockStyleVariations']);
+		add_action('enqueue_block_editor_assets', [$this, 'blockVariations']);
+	}
+
+	public function blockVariations(): void
+	{
+		wp_enqueue_script(
+			'block-style-variations',
+			plugin_dir_url(__DIR__) . 'assets/js/block-variations.js',
+			[
+				'wp-blocks',
+				'wp-dom-ready',
+				'wp-edit-post'
+			]
+		);
 	}
 }

--- a/app/Scripts.php
+++ b/app/Scripts.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace GovukComponents;
+
+class Scripts
+{
+}

--- a/app/Scripts.php
+++ b/app/Scripts.php
@@ -2,6 +2,10 @@
 
 namespace GovukComponents;
 
-class Scripts
+class Scripts implements \Dxw\Iguana\Registerable
 {
+	public function register(): void
+	{
+
+	}
 }

--- a/app/Scripts.php
+++ b/app/Scripts.php
@@ -6,6 +6,6 @@ class Scripts implements \Dxw\Iguana\Registerable
 {
 	public function register(): void
 	{
-
+		add_action('enqueue_block_editor_assets', [$this, 'govukComponentsBlockStyleVariations']);
 	}
 }

--- a/app/di.php
+++ b/app/di.php
@@ -25,3 +25,5 @@ $registrar->addInstance(new \GovukComponents\BlockController(
 $registrar->addInstance(new \GovukComponents\Options(
 	$registrar->getInstance(\GovukComponents\BlockController::class)
 ));
+
+$registrar->addInstance(new \GovukComponents\Scripts());

--- a/assets/js/block-variations.js
+++ b/assets/js/block-variations.js
@@ -1,0 +1,40 @@
+wp.blocks.registerBlockVariation('core/button', {
+	name: 'govuk-default',
+	title: 'GOV.UK Default',
+	attributes: {
+		className: 'govuk-button',
+	},
+	isDefault: false
+});
+
+wp.blocks.registerBlockVariation('core/button', {
+	name: 'govuk-start',
+	title: 'GOV.UK Start',
+	attributes: {
+		className: 'govuk-button--start',
+	},
+});
+
+wp.blocks.registerBlockVariation('core/button', {
+	name: 'govuk-secondary',
+	title: 'GOV.UK Secondary',
+	attributes: {
+		className: 'govuk-button--secondary',
+	},
+});
+
+wp.blocks.registerBlockVariation('core/button', {
+	name: 'govuk-warning',
+	title: 'GOV.UK Warning',
+	attributes: {
+		className: 'govuk-button--warning',
+	},
+});
+
+wp.blocks.registerBlockVariation('core/button', {
+	name: 'govuk-inverse',
+	title: 'GOV.UK Inverse',
+	attributes: {
+		className: 'govuk-button--inverse',
+	},
+});

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -4,4 +4,8 @@ describe(\GovukComponents\Scripts::class, function () {
 	beforeEach(function () {
 		$this->scripts = new GovukComponents\Scripts();
 	});
+
+	it('implements the Registerable interface', function () {
+		expect($this->scripts)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+	});
 });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -1,0 +1,7 @@
+<?php
+
+describe(\GovukComponents\Scripts::class, function () {
+	beforeEach(function () {
+		$this->scripts = new GovukComponents\Scripts();
+	});
+});

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -8,4 +8,15 @@ describe(\GovukComponents\Scripts::class, function () {
 	it('implements the Registerable interface', function () {
 		expect($this->scripts)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
 	});
+
+	describe('->register()', function () {
+		it('adds the actions', function () {
+			allow('add_action')->toBeCalled();
+
+			expect('add_action')->toBeCalled()->once()
+			->with('enqueue_block_editor_assets', [$this->scripts, 'govukComponentsBlockStyleVariations']);
+
+			$this->scripts->register();
+		});
+	});
 });

--- a/spec/scripts.spec.php
+++ b/spec/scripts.spec.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kahlan\Arg;
+
 describe(\GovukComponents\Scripts::class, function () {
 	beforeEach(function () {
 		$this->scripts = new GovukComponents\Scripts();
@@ -14,9 +16,21 @@ describe(\GovukComponents\Scripts::class, function () {
 			allow('add_action')->toBeCalled();
 
 			expect('add_action')->toBeCalled()->once()
-			->with('enqueue_block_editor_assets', [$this->scripts, 'govukComponentsBlockStyleVariations']);
+			->with('enqueue_block_editor_assets', [$this->scripts, 'blockVariations']);
 
 			$this->scripts->register();
+		});
+	});
+
+	describe('->blockStyleVariations()', function () {
+		it('enqueues block style variations script', function () {
+			allow('wp_enqueue_script')->toBeCalled();
+			allow('plugin_dir_url')->toBeCalled();
+
+			expect('wp_enqueue_script')->toBeCalled()->once()
+			->with('block-style-variations', Arg::toBeA('string'), Arg::toBeAn('array'));
+
+			$this->scripts->blockVariations();
 		});
 	});
 });


### PR DESCRIPTION
This PR adds variations of the core/button class for the block editor. Currently, is inserts the css classes directly into the block so when a `Buttons` block is inserted, when adding more buttons it should list the variations of the core/button but styled differently.

Screenshot:
<img width="394" height="377" alt="image" src="https://github.com/user-attachments/assets/96193f35-5dbe-4c55-a371-07c09f65c8d6" />

To test:
1. Fetch this branch `feature/block-button-variation`
2. In the admin dashboard, create a new page/post or go to an existing one.
3. Insert a `Buttons` block, by default it should also insert a core/button.
4. In the `Buttons` block insert more button blocks and it should show more variations like in the screen shot.
5. Save and publish, and view the page. Inspect the element and the css class should be inserted into the element.