### PR TITLE
Feature/register block category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Old Details block that requires ACF
 - `aria-labelledby` attribute from `<div>` element with no specified role.
 
+### Changed
+
+- Category title and slug updated from 'Custom' / 'govuk-custom' to 'GOV.UK Design System' / 'govuk-components'
+
 ## [0.4.3] - 2024-09-09
 
 ### Fixed

--- a/app/BlockCategory.php
+++ b/app/BlockCategory.php
@@ -11,7 +11,7 @@ class BlockCategory implements \Dxw\Iguana\Registerable
 
 	public function newBlocksCategory($categories)
 	{
-		$block_category = [ 'title' => 'Custom', 'slug' => 'govuk-custom' ];
+		$block_category = [ 'title' => 'GOV.UK Design System', 'slug' => 'govuk-components' ];
 		$category_slugs = array_column($categories, 'slug');
 
 		if (! in_array($block_category['slug'], $category_slugs, true)) {

--- a/app/Blocks/Accordion/build/block.json
+++ b/app/Blocks/Accordion/build/block.json
@@ -4,7 +4,7 @@
   "name": "govuk-components/accordion",
   "version": "0.1.0",
   "title": "GOV.UK Accordion",
-  "category": "",
+  "category": "govuk-components",
   "allowedBlocks": [
     "govuk-components/accordion-row"
   ],
@@ -48,7 +48,7 @@
     }
   },
   "providesContext": {
-    "govukblogs/showAll": "showAll"
+    "govuk-components/showAll": "showAll"
   },
   "textdomain": "govuk-components-plugin",
   "editorScript": "file:./index.js"

--- a/app/Blocks/Accordion/src/block.json
+++ b/app/Blocks/Accordion/src/block.json
@@ -4,7 +4,7 @@
 	"name": "govuk-components/accordion",
 	"version": "0.1.0",
 	"title": "GOV.UK Accordion",
-	"category": "",
+	"category": "govuk-components",
 	"allowedBlocks": [ "govuk-components/accordion-row" ],
 	"description": "Let users show and hide sections of related content on a page.",
 	"example": {

--- a/app/Blocks/AccordionRow/build/block.json
+++ b/app/Blocks/AccordionRow/build/block.json
@@ -4,7 +4,7 @@
   "name": "govuk-components/accordion-row",
   "version": "0.1.0",
   "title": "GOV.UK Accordion Row",
-  "category": "",
+  "category": "govuk-components",
   "parent": [
     "govuk-components/accordion"
   ],

--- a/app/Blocks/AccordionRow/src/block.json
+++ b/app/Blocks/AccordionRow/src/block.json
@@ -4,7 +4,7 @@
 	"name": "govuk-components/accordion-row",
 	"version": "0.1.0",
 	"title": "GOV.UK Accordion Row",
-	"category": "",
+	"category": "govuk-components",
 	"parent": [ "govuk-components/accordion" ],
 	"description": "A individual row to add to a GOV.UK accordion.",
 	"example": {},

--- a/app/Blocks/Details/build/block.json
+++ b/app/Blocks/Details/build/block.json
@@ -4,7 +4,7 @@
   "name": "govuk-components/details",
   "version": "0.1.0",
   "title": "GOV.UK Details",
-  "category": "",
+  "category": "govuk-components",
   "description": "Make a page easier to scan by letting users reveal more detailed information only if they need it.",
   "example": {},
   "icon": "arrow-down",

--- a/app/Blocks/Details/src/block.json
+++ b/app/Blocks/Details/src/block.json
@@ -4,7 +4,7 @@
 	"name": "govuk-components/details",
 	"version": "0.1.0",
 	"title": "GOV.UK Details",
-	"category": "",
+	"category": "govuk-components",
 	"description": "Make a page easier to scan by letting users reveal more detailed information only if they need it.",
 	"example": {},
     "icon": "arrow-down",

--- a/app/Blocks/InsetText/build/block.json
+++ b/app/Blocks/InsetText/build/block.json
@@ -4,7 +4,7 @@
   "name": "govuk-components/inset-text",
   "version": "0.1.0",
   "title": "GOV.UK Inset Text",
-  "category": "",
+  "category": "govuk-components",
   "description": "Use inset and a highlight bar to differentiate a block of text from the content that surrounds it",
   "example": {
     "innerBlocks": [

--- a/app/Blocks/InsetText/src/block.json
+++ b/app/Blocks/InsetText/src/block.json
@@ -4,7 +4,7 @@
 	"name": "govuk-components/inset-text",
 	"version": "0.1.0",
 	"title": "GOV.UK Inset Text",
-	"category": "",
+	"category": "govuk-components",
 	"description": "Use inset and a highlight bar to differentiate a block of text from the content that surrounds it",
 	"example": {
 		"innerBlocks": [

--- a/spec/block_category.spec.php
+++ b/spec/block_category.spec.php
@@ -39,8 +39,8 @@ describe(\GovukComponents\BlockCategory::class, function () {
 				$result = $this->blockCategory->newBlocksCategory($categories);
 				expect($result)->toEqual([
 					[
-						"title" => "Custom",
-						"slug"  => "govuk-custom"
+						"title" => "GOV.UK Design System",
+						"slug"  => "govuk-components"
 					],
 					[
 						'slug'  => 'text',
@@ -61,8 +61,8 @@ describe(\GovukComponents\BlockCategory::class, function () {
 			it('returns the array unchanged', function () {
 				$categories = [
 					[
-						"title" => "Custom",
-						"slug"  => "govuk-custom"
+						"title" => "GOV.UK Design System",
+						"slug"  => "govuk-components"
 					],
 					[
 						'slug'  => 'text',


### PR DESCRIPTION
This PR updates the block category to `GOV.UK Design System` with the slug, `govuk-components`.

To test:
1. Fetch this branch `feature/register-block-category`.
2. In the admin, create a new page/post or go to an existing post.
3. Click on the block inserter at the top to open the left sidebar to search for a Block.
4. Check that the Accordion, Details and Inset Text block is under GOV.UK Design System category. Selecting Accordion should also show Accordion Row in the new category.

<img width="346" height="244" alt="image" src="https://github.com/user-attachments/assets/50211359-c21b-48fb-ad89-0286ff555b04" />
