### PR TITLE
Fix name in package.json

### DIFF
--- a/app/Blocks/AccordionRow/package-lock.json
+++ b/app/Blocks/AccordionRow/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "accordionrow",
+  "name": "accordion-row",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "accordionrow",
+      "name": "accordion-row",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {


### PR DESCRIPTION
This PR fixes a typo in the package-lock.json file.