### PR TITLE
Remove sed step when running psalm in action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,4 @@ jobs:
             ${{ runner.os }}-composer-
       - name: Install dependencies
         run: composer install --no-interaction
-      - name: Skip checking node_modules
-        run: sed -i 's#<directory name="app/Blocks/\*/node_modules"/>##' psalm.xml
       - run: vendor/bin/psalm

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,7 +10,7 @@
 >
     <projectFiles>
         <directory name="app"/>
-        <ignoreFiles>
+        <ignoreFiles allowMissingFiles="true">
             <file name="app/di.php"/>
             <file name="vendor.phar"/>
             <directory name="app/Blocks/*/node_modules"/>


### PR DESCRIPTION
This PR removes the sed step from the GitHub Action and configures Psalm with <ignoreFiles allowMissingFiles="true"> instead. This provides a cleaner and more reliable way to skip missing files like node_modules.