### PR TITLE
Phase banner is applied with wp_body_open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GOV.UK Details block for the block editor
 - GOV.UK Phase banner component and settings
 - Add link to components options page from plugins page
+- Phase banner appears in response to wp_body_open hook
 
 ### Removed
 

--- a/app/Components/PhaseBanner.php
+++ b/app/Components/PhaseBanner.php
@@ -9,6 +9,7 @@ final class PhaseBanner implements \Dxw\Iguana\Registerable
 	{
 		/** @psalm-suppress HookNotFound */
 		add_action('dxw_flatpack_before_header', [$this, 'displayPhaseBanner'], 10, 0);
+		add_action('wp_body_open', [$this, 'displayPhaseBanner'], 10, 0);
 	}
 
 	public function displayPhaseBanner(): void

--- a/spec/components/phase_banner.spec.php
+++ b/spec/components/phase_banner.spec.php
@@ -12,8 +12,9 @@ describe(\GovukComponents\Components\PhaseBanner::class, function () {
 	describe('->register()', function () {
 		it('adds the actions', function () {
 			allow('add_action')->toBeCalled();
-			expect('add_action')->toBeCalled()->once();
+			expect('add_action')->toBeCalled()->times(2);
 			expect('add_action')->toBeCalled()->with('dxw_flatpack_before_header', [$this->banner, 'displayPhaseBanner']);
+			expect('add_action')->toBeCalled()->with('wp_body_open', [$this->banner, 'displayPhaseBanner']);
 			$this->banner->register();
 		});
 	});


### PR DESCRIPTION
Fixes #98 

Previously we added the phase banner to pages in response to a dxw specific hook that we provide in a parent theme.

This makes the banner unusable for anyone outside dxw, but using a standard WordPress hook would not work on our sites.

This commit adds the phase banner in response to the wp_body_open hook, which is provided by WordPress Core. This means that non-dxw themes can use the component, but any theme using both hooks will presumably find the banner appears twice.

See:
https://developer.wordpress.org/reference/hooks/wp_body_open/