### PR TITLE
Only show content if it is not empty

### DIFF
--- a/app/Components/NotificationBanner.php
+++ b/app/Components/NotificationBanner.php
@@ -63,7 +63,7 @@ final class NotificationBanner implements \Dxw\Iguana\Registerable
 <?= esc_html($heading); ?>
       </h2>
     </div>
-<?php if (!empty($content)): ?>
+<?php if (!empty(trim($content))): ?>
     <div class="govuk-notification-banner__content">
 <?= wp_kses_post($content); ?>
     </div>

--- a/app/Components/NotificationBanner.php
+++ b/app/Components/NotificationBanner.php
@@ -63,9 +63,11 @@ final class NotificationBanner implements \Dxw\Iguana\Registerable
 <?= esc_html($heading); ?>
       </h2>
     </div>
+<?php if (!empty($content)): ?>
     <div class="govuk-notification-banner__content">
 <?= wp_kses_post($content); ?>
     </div>
+<?php endif; ?>
   </div>
 </div>
 <?php


### PR DESCRIPTION
## Description

This PR adds a small condition so the notification banner's content container only show when there's actual content passed in the options. This gives editors a bit more flexibility, since the content needs styling but isn't always needed. The `:empty` selector doesn't work here because the generated empty `div` contains whitespace.

## How to Test
1. Access the [options page](http://localhost/wp-admin/options-general.php?page=acf-options-gov-uk-components)
2. Set `Show Notification Banner` to `Banner on`
3. The heading should be autofilled with a value
4. Ensure the content field is empty
5. Save the changes
6. Access the homepage of the site and confirm the banner container is not being displayed

## Screenshots
| Before | After |
|:--|:--|
| <img width="961" height="109" alt="image" src="https://github.com/user-attachments/assets/51500ed9-0c36-4589-bcad-fee4e1a60b99" /> | <img width="961" height="77" alt="image" src="https://github.com/user-attachments/assets/6b8e2cf8-0e10-47f3-9b17-c77321a2c2a1" /> |

