### PR TITLE
Make GOV.UK Components options page filterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure accordion rows and headers have unique ID
 - GOV.UK Notification banner component and settings
 - GOV.UK Pagination block for the block editor
+- Support for filtering the ACF options page arguments through the `govuk_components_plugin_options_page` filter.
 
 ### Removed
 

--- a/app/Options.php
+++ b/app/Options.php
@@ -53,11 +53,15 @@ final class Options implements \Dxw\Iguana\Registerable
 	public function addPage(): void
 	{
 		if (function_exists('acf_add_options_page')) {
-			acf_add_options_page([
+			$args = [
 				'page_title' => 'GOV.UK Components',
 				'capability' => 'edit_users',
 				'parent_slug' => 'options-general.php'
-			]);
+			];
+			/** @var array */
+			$args = apply_filters('govuk_components_plugin_options_page', $args);
+
+			acf_add_options_page($args);
 		}
 	}
 

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -54,8 +54,24 @@ describe(\GovukComponents\Options::class, function () {
 		it('adds the options page', function () {
 			allow('function_exists')->toBeCalled()->andReturn(true);
 			allow('acf_add_options_page')->toBeCalled();
+			allow('apply_filters')->toBeCalled()->andReturn([]);
+
 			expect('acf_add_options_page')->toBeCalled()->once();
 			expect('acf_add_options_page')->toBeCalled()->with(Arg::toBeAn('array'));
+
+			$this->options->addPage();
+		});
+
+		it('applies the filter to the arguments', function () {
+			allow('function_exists')->toBeCalled()->andReturn(true);
+			allow('acf_add_options_page')->toBeCalled();
+			allow('apply_filters')->toBeCalled()->andRun(function ($hook, $args) {
+				$args['capability'] = 'edit_posts';
+				return $args;
+			});
+
+			expect('acf_add_options_page')->toBeCalled()->with(Arg::toContain('edit_posts'));
+
 			$this->options->addPage();
 		});
 	});


### PR DESCRIPTION
## Description
This changeset introduces a filter `govuk_components_plugin_options_page` that allows third-party code to change the arguments before the ACF options page is registered.

This is especially valuable when adjusting which user roles can access the Options page, since access requirements often differ between organisations.

## How to test
1. Add the following to the `functions.php` of the theme you're currently working on:
```php
add_filter('govuk_components_plugin_options_page', function ($args) {
    do_action('qm/debug', $args);
    return $args;
});
```
2. Confirm you can see the arguments in the Query Monitor logs