### PR TITLE
Add filter to allow modifying ACF field group args in banner options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GOV.UK Notification banner component and settings
 - GOV.UK Pagination block for the block editor
 - Support for filtering the ACF options page arguments through the `govuk_components_plugin_options_page` filter.
+- Support for customising ACF notification banner settings via the `govuk_components_notification_banner_options`  and `govuk_components_notification_banner_enabled` filters.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure accordion rows and headers have unique ID
 - GOV.UK Notification banner component and settings
 - GOV.UK Pagination block for the block editor
-- Support for filtering the ACF options page arguments through the `govuk_components_plugin_options_page` filter.
+- Support for filtering the ACF options page arguments through the `govuk_components_options_page` filter.
 - Support for customising ACF notification banner settings via the `govuk_components_notification_banner_options`  and `govuk_components_notification_banner_enabled` filters.
 
 ### Removed

--- a/app/Components/NotificationBanner.php
+++ b/app/Components/NotificationBanner.php
@@ -16,7 +16,9 @@ final class NotificationBanner implements \Dxw\Iguana\Registerable
 	{
 		/** @var string $show */
 		$show = get_field('govuk_components_notification_banner_show', 'option');
-		return $show === 'off';
+
+		/** @var bool */
+		return apply_filters('govuk_components_notification_banner_enabled', $show === 'off');
 	}
 
 	public function enqueueDynamicStyles(): void

--- a/app/Components/NotificationBanner.php
+++ b/app/Components/NotificationBanner.php
@@ -18,12 +18,12 @@ final class NotificationBanner implements \Dxw\Iguana\Registerable
 		$show = get_field('govuk_components_notification_banner_show', 'option');
 
 		/** @var bool */
-		return apply_filters('govuk_components_notification_banner_enabled', $show === 'off');
+		return apply_filters('govuk_components_notification_banner_enabled', $show === 'on');
 	}
 
 	public function enqueueDynamicStyles(): void
 	{
-		if ($this->isBannerOn()) {
+		if (!$this->isBannerOn()) {
 			return;
 		}
 
@@ -47,7 +47,7 @@ final class NotificationBanner implements \Dxw\Iguana\Registerable
 
 	public function displayNotificationBanner(): void
 	{
-		if ($this->isBannerOn()) {
+		if (!$this->isBannerOn()) {
 			return;
 		}
 

--- a/app/Options.php
+++ b/app/Options.php
@@ -59,7 +59,7 @@ final class Options implements \Dxw\Iguana\Registerable
 				'parent_slug' => 'options-general.php'
 			];
 			/** @var array */
-			$args = apply_filters('govuk_components_plugin_options_page', $args);
+			$args = apply_filters('govuk_components_options_page', $args);
 
 			acf_add_options_page($args);
 		}

--- a/app/Options.php
+++ b/app/Options.php
@@ -190,7 +190,7 @@ final class Options implements \Dxw\Iguana\Registerable
 				'description' => '',
 			]);
 
-			acf_add_local_field_group([
+			$notificationBannerFields = [
 				'key' => 'govuk_components_notification_banner_group',
 				'title' => 'Notification Banner Settings',
 				'fields' => [
@@ -338,7 +338,11 @@ final class Options implements \Dxw\Iguana\Registerable
 				'hide_on_screen' => '',
 				'active' => 1,
 				'description' => 'A field group for global site content.',
-			]);
+			];
+
+			/** @var array */
+			$notificationBannerFields = apply_filters('govuk_components_notification_banner_options', $notificationBannerFields);
+			acf_add_local_field_group($notificationBannerFields);
 
 		endif;
 	}

--- a/spec/components/notification_banner.spec.php
+++ b/spec/components/notification_banner.spec.php
@@ -27,6 +27,10 @@ describe(\GovukComponents\Components\NotificationBanner::class, function () {
 			allow('esc_attr')->toBeCalled()->andRun(function ($val) {
 				return $val;
 			});
+
+			allow('apply_filters')->toBeCalled()->andRun(function ($hook, $args) {
+				return $args;
+			});
 		});
 		context('The banner is switched off in options', function () {
 			it('does nothing', function () {
@@ -71,6 +75,10 @@ HTML;
 		beforeEach(function () {
 			allow('wp_kses_post')->toBeCalled()->andRun(function ($val) {
 				return $val;
+			});
+
+			allow('apply_filters')->toBeCalled()->andRun(function ($hook, $args) {
+				return $args;
 			});
 		});
 		context('The banner is switched off in options', function () {

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -89,6 +89,8 @@ describe(\GovukComponents\Options::class, function () {
 				1 => 'block_2_option_name'
 			]);
 			expect($this->blockController)->toReceive('getDefaultBlockOptions')->once();
+
+			allow('apply_filters')->toBeCalled()->andReturn([]);
 			allow('acf_add_local_field_group')->toBeCalled();
 			expect('acf_add_local_field_group')->toBeCalled()->times(3);
 			expect('acf_add_local_field_group')->toBeCalled()->with(Arg::toBeAn('array'));


### PR DESCRIPTION
## Description 

By adding these filters we allow more flexibility for extending the banner options, such as: adding extra fields for scheduling when the banner should be displayed.

## How to Test
1. Confirm you're able to use the filters by adding the following to `functions.php`:
```php
add_filter('govuk_components_notification_banner_options', function ($args) {
    do_action('qm/debug', $args);
    return $args;
});

add_filter('govuk_components_notification_banner_enabled', function ($args) {
    do_action('qm/debug', $args);
    return $args;
});
```