### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.0] - 2026-01-07
 
 ### Added
 

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: GOV.UK Components
 Description: Adds components from the GOV.UK Frontend to the block editor
-Version: 0.4.2
+Version: 1.0.0
 Author: dxw
 Author URI: https://www.dxw.com
 */


### PR DESCRIPTION
This PR is just intended to make v1.0.0 available.

However, I've hit up against a bit of an issue: Psalm is erroring, despite there being no changes to the PHP and the last merge to `main` passing.

I *think* this is due to the WordPress plugin, as the errors stop if I remove that. That would match with the WordPress-related commits referenced here: https://github.com/vimeo/psalm/issues/11588

I can't find a useful way of resolving this though. The options I've found are:

a) Remove the WordPress plugin and go back to using comments/ignore rules to repress the Psalm errors
b) Downgrade the WordPress plugin to v2, which then necessitates a Pslam downgrade to v4, which then results in errors because Psalm doesn't understand some of the more recent code/comments (e.g. `#[\Override]`), which we'd have to remove and later reinstate
c) Switch off Psalm altogether until this is resolved

All these feel like backwards steps, so I'm unsure as to what the best approach is. Ideas?